### PR TITLE
sweepbatcher: subtle adjustments for change

### DIFF
--- a/loopout_test.go
+++ b/loopout_test.go
@@ -280,6 +280,7 @@ func testCustomSweepConfTarget(t *testing.T) {
 	// yields a much higher fee rate.
 	ctx.Lnd.SetFeeEstimate(testReq.SweepConfTarget, 250)
 	ctx.Lnd.SetFeeEstimate(DefaultSweepConfTarget, 10000)
+	ctx.Lnd.SetMinRelayFee(250)
 
 	cfg := newSwapConfig(
 		&lnd.LndServices, loopdb.NewStoreMock(t), server, nil,

--- a/sweepbatcher/greedy_batch_selection.go
+++ b/sweepbatcher/greedy_batch_selection.go
@@ -210,6 +210,13 @@ func estimateBatchWeight(batch *batch) (feeDetails, error) {
 			err)
 	}
 
+	// Add change output weights.
+	for _, s := range batch.sweeps {
+		if s.change != nil {
+			weight.AddOutput(s.change.PkScript)
+		}
+	}
+
 	// Add inputs.
 	for _, sweep := range batch.sweeps {
 		if sweep.nonCoopHint || sweep.coopFailed {

--- a/sweepbatcher/presigned_test.go
+++ b/sweepbatcher/presigned_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	minRelayFeeRate = chainfee.FeePerKwFloor
+)
+
 // TestOrderedSweeps checks that methods batch.getOrderedSweeps and
 // batch.getSweepsGroups works properly.
 func TestOrderedSweeps(t *testing.T) {
@@ -561,7 +565,7 @@ func TestEnsurePresigned(t *testing.T) {
 			}
 
 			err := ensurePresigned(
-				ctx, tc.sweeps, c,
+				ctx, tc.sweeps, c, minRelayFeeRate,
 				&chaincfg.RegressionNetParams,
 			)
 			switch {
@@ -1010,7 +1014,7 @@ func TestPresign(t *testing.T) {
 			err := presign(
 				ctx, tc.presigner, tc.destAddr,
 				tc.primarySweepID, tc.sweeps,
-				tc.nextBlockFeeRate,
+				tc.nextBlockFeeRate, minRelayFeeRate,
 			)
 			if tc.wantErr != "" {
 				require.Error(t, err)

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -125,6 +125,9 @@ type sweep struct {
 
 	// presigned is set, if the sweep should be handled in presigned mode.
 	presigned bool
+
+	// change is the optional change output of the sweep.
+	change *wire.TxOut
 }
 
 // batchState is the state of the batch.

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -1245,9 +1245,9 @@ func (b *batch) createPsbt(unsignedTx *wire.MsgTx, sweeps []sweep) ([]byte,
 // outputs. If the main output value is below dust limit this function will
 // return an error.
 func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
-	currentHeight int32, feeRate chainfee.SatPerKWeight) (
-	*wire.MsgTx, lntypes.WeightUnit, btcutil.Amount, btcutil.Amount,
-	error) {
+	currentHeight int32, feeRate chainfee.SatPerKWeight,
+	minRelayFeeRate chainfee.SatPerKWeight) (*wire.MsgTx,
+	lntypes.WeightUnit, btcutil.Amount, btcutil.Amount, error) {
 
 	// Sanity check, there should be at least 1 sweep in this batch.
 	if len(sweeps) == 0 {
@@ -1349,7 +1349,14 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 	}
 
 	// Clamp the calculated fee to the max allowed fee amount for the batch.
-	fee := clampBatchFee(feeForWeight, batchAmt-btcutil.Amount(sumChange))
+	fee, err := clampBatchFee(
+		feeForWeight, batchAmt-btcutil.Amount(sumChange),
+		minRelayFeeRate, weight,
+	)
+	if err != nil {
+		return nil, 0, 0, 0, fmt.Errorf("failed to clamp batch "+
+			"fee: %w", err)
+	}
 
 	// Ensure that batch amount exceeds the sum of change outputs and the
 	// fee, and that it is also greater than dust limit for the main
@@ -1465,15 +1472,21 @@ func (b *batch) publishMixedBatch(ctx context.Context) (btcutil.Amount, error,
 	// known in advance to be non-cooperative (nonCoopHint) and not failed
 	// to sign cooperatively in previous rounds (coopFailed). If any of them
 	// fails, the sweep is excluded from all following rounds and another
-	// round is attempted. Otherwise the cycle completes and we sign the
+	// round is attempted. Otherwise, the cycle completes and we sign the
 	// remaining sweeps non-cooperatively.
 	var (
-		tx           *wire.MsgTx
-		weight       lntypes.WeightUnit
-		feeForWeight btcutil.Amount
-		fee          btcutil.Amount
-		coopInputs   int
+		tx              *wire.MsgTx
+		weight          lntypes.WeightUnit
+		feeForWeight    btcutil.Amount
+		fee             btcutil.Amount
+		minRelayFeeRate chainfee.SatPerKWeight
+		coopInputs      int
 	)
+	minRelayFeeRate, err := b.wallet.MinRelayFee(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get min relay fee: %w", err),
+			false
+	}
 	for attempt := 1; ; attempt++ {
 		b.Infof("Attempt %d of collecting cooperative signatures.",
 			attempt)
@@ -1482,6 +1495,7 @@ func (b *batch) publishMixedBatch(ctx context.Context) (btcutil.Amount, error,
 		var err error
 		tx, weight, feeForWeight, fee, err = constructUnsignedTx(
 			sweeps, address, b.currentHeight, b.rbfCache.FeeRate,
+			minRelayFeeRate,
 		)
 		if err != nil {
 			return 0, fmt.Errorf("failed to construct tx: %w", err),
@@ -1533,7 +1547,7 @@ func (b *batch) publishMixedBatch(ctx context.Context) (btcutil.Amount, error,
 		// If there was any failure of cooperative signing, we need to
 		// update weight estimates (since non-cooperative signing has
 		// larger witness) and hence update the whole transaction and
-		// all the signatures. Otherwise we complete cooperative part.
+		// all the signatures. Otherwise, we complete cooperative part.
 		if !newCoopFailures {
 			break
 		}
@@ -1669,7 +1683,7 @@ func (b *batch) publishMixedBatch(ctx context.Context) (btcutil.Amount, error,
 	}
 
 	// Publish the transaction.
-	err := b.wallet.PublishTransaction(
+	err = b.wallet.PublishTransaction(
 		ctx, tx, b.cfg.txLabeler(b.id),
 	)
 	if err != nil {
@@ -2565,16 +2579,25 @@ func (b *batch) persistSweep(ctx context.Context, sweep sweep,
 
 // clampBatchFee takes the fee amount and total amount of the sweeps in the
 // batch and makes sure the fee is not too high. If the fee is too high, it is
-// clamped to the maximum allowed fee.
-func clampBatchFee(fee btcutil.Amount,
-	totalAmount btcutil.Amount) btcutil.Amount {
+// clamped to the maximum allowed fee. If the clamped fee results in a fee rate
+// below the minimum relay fee, an error is returned.
+func clampBatchFee(fee btcutil.Amount, totalAmount btcutil.Amount,
+	minRelayFeeRate chainfee.SatPerKWeight,
+	weight lntypes.WeightUnit) (btcutil.Amount, error) {
 
 	maxFeeAmount := btcutil.Amount(float64(totalAmount) *
 		maxFeeToSwapAmtRatio)
 
+	clampedFee := fee
 	if fee > maxFeeAmount {
-		return maxFeeAmount
+		clampedFee = maxFeeAmount
 	}
 
-	return fee
+	clampedFeeRate := chainfee.NewSatPerKWeight(clampedFee, weight)
+	if clampedFeeRate < minRelayFeeRate {
+		return 0, fmt.Errorf("clamped fee rate %v is less than "+
+			"minimum relay fee %v", clampedFeeRate, minRelayFeeRate)
+	}
+
+	return clampedFee, nil
 }

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -1358,12 +1358,12 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 			"fee: %w", err)
 	}
 
-	// Ensure that batch amount exceeds the sum of change outputs and the
-	// fee, and that it is also greater than dust limit for the main
-	// output.
+	// Ensure that batch amount is equal or exceeds the sum of change
+	// outputs and the fee, and that it is also greater than dust limit
+	// for the main output.
 	dustLimit := utils.DustLimitForPkScript(batchPkScript)
 	if fee+btcutil.Amount(sumChange)+dustLimit > batchAmt {
-		return nil, 0, 0, 0, fmt.Errorf("batch amount %v is <= the "+
+		return nil, 0, 0, 0, fmt.Errorf("batch amount %v is < the "+
 			"sum of change outputs %v plus fee %v and dust "+
 			"limit %v", batchAmt, btcutil.Amount(sumChange),
 			fee, dustLimit)

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/swap"
 	sweeppkg "github.com/lightninglabs/loop/sweep"
+	"github.com/lightninglabs/loop/utils"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/input"
@@ -1239,10 +1240,14 @@ func (b *batch) createPsbt(unsignedTx *wire.MsgTx, sweeps []sweep) ([]byte,
 }
 
 // constructUnsignedTx creates unsigned tx from the sweeps, paying to the addr.
-// It also returns absolute fee (from weight and clamped).
+// It also returns absolute fee (from weight and clamped). The main output is
+// the first output of the transaction, followed by an optional list of change
+// outputs. If the main output value is below dust limit this function will
+// return an error.
 func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
-	currentHeight int32, feeRate chainfee.SatPerKWeight) (*wire.MsgTx,
-	lntypes.WeightUnit, btcutil.Amount, btcutil.Amount, error) {
+	currentHeight int32, feeRate chainfee.SatPerKWeight) (
+	*wire.MsgTx, lntypes.WeightUnit, btcutil.Amount, btcutil.Amount,
+	error) {
 
 	// Sanity check, there should be at least 1 sweep in this batch.
 	if len(sweeps) == 0 {
@@ -1253,6 +1258,13 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 	batchTx := &wire.MsgTx{
 		Version:  2,
 		LockTime: uint32(currentHeight),
+	}
+
+	var changeOutputs []*wire.TxOut
+	for _, sweep := range sweeps {
+		if sweep.change != nil {
+			changeOutputs = append(changeOutputs, sweep.change)
+		}
 	}
 
 	// Add transaction inputs and estimate its weight.
@@ -1300,6 +1312,11 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 			"failed: %w", err)
 	}
 
+	// Add the optional change outputs to weight estimates.
+	for _, o := range changeOutputs {
+		weightEstimate.AddOutput(o.PkScript)
+	}
+
 	// Keep track of the total amount this batch is sweeping back.
 	batchAmt := btcutil.Amount(0)
 	for _, sweep := range sweeps {
@@ -1317,15 +1334,78 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 		feeForWeight++
 	}
 
-	// Clamp the calculated fee to the max allowed fee amount for the batch.
-	fee := clampBatchFee(feeForWeight, batchAmt)
-
 	// Add the batch transaction output, which excludes the fees paid to
-	// miners.
+	// miners. Reduce the amount by the sum of change outputs, if any.
+	var sumChange int64
+	for _, change := range changeOutputs {
+		sumChange += change.Value
+	}
+
+	// Ensure that the batch amount is greater than the sum of change.
+	if batchAmt <= btcutil.Amount(sumChange) {
+		return nil, 0, 0, 0, fmt.Errorf("batch amount %v is <= the "+
+			"sum of change outputs %v", batchAmt,
+			btcutil.Amount(sumChange))
+	}
+
+	// Clamp the calculated fee to the max allowed fee amount for the batch.
+	fee := clampBatchFee(feeForWeight, batchAmt-btcutil.Amount(sumChange))
+
+	// Ensure that batch amount exceeds the sum of change outputs and the
+	// fee, and that it is also greater than dust limit for the main
+	// output.
+	dustLimit := utils.DustLimitForPkScript(batchPkScript)
+	if fee+btcutil.Amount(sumChange)+dustLimit > batchAmt {
+		return nil, 0, 0, 0, fmt.Errorf("batch amount %v is <= the "+
+			"sum of change outputs %v plus fee %v and dust "+
+			"limit %v", batchAmt, btcutil.Amount(sumChange),
+			fee, dustLimit)
+	}
+
+	// Add the main output first.
 	batchTx.AddTxOut(&wire.TxOut{
 		PkScript: batchPkScript,
-		Value:    int64(batchAmt - fee),
+		Value:    int64(batchAmt-fee) - sumChange,
 	})
+	// Then add change outputs.
+	for _, txOut := range changeOutputs {
+		batchTx.AddTxOut(&wire.TxOut{
+			PkScript: txOut.PkScript,
+			Value:    txOut.Value,
+		})
+	}
+
+	// Check that for each swap, inputs exceed the change outputs.
+	if len(changeOutputs) != 0 {
+		swap2Inputs := make(map[lntypes.Hash]btcutil.Amount)
+		swap2Change := make(map[lntypes.Hash]btcutil.Amount)
+		for _, sweep := range sweeps {
+			swap2Inputs[sweep.swapHash] += sweep.value
+			if sweep.change != nil {
+				swap2Change[sweep.swapHash] +=
+					btcutil.Amount(sweep.change.Value)
+			}
+		}
+
+		for swapHash, inputs := range swap2Inputs {
+			change := swap2Change[swapHash]
+			if inputs <= change {
+				return nil, 0, 0, 0, fmt.Errorf(""+
+					"inputs %v <= change %v for swap %x",
+					inputs, change, swapHash[:6])
+			}
+		}
+	}
+
+	// Ensure that each output is above dust limit.
+	for _, txOut := range batchTx.TxOut {
+		dustLimit = utils.DustLimitForPkScript(txOut.PkScript)
+		if btcutil.Amount(txOut.Value) < dustLimit {
+			return nil, 0, 0, 0, fmt.Errorf("output %v is below "+
+				"dust limit %v", btcutil.Amount(txOut.Value),
+				dustLimit)
+		}
+	}
 
 	return batchTx, weight, feeForWeight, fee, nil
 }

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -444,7 +444,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 			currentHeight:   800_000,
 			feeRate:         1_000,
 			minRelayFeeRate: 50,
-			wantErr: "batch amount 0.00100294 BTC is <= the sum " +
+			wantErr: "batch amount 0.00100294 BTC is < the sum " +
 				"of change outputs 0.00100000 BTC plus fee " +
 				"0.00000058 BTC and dust limit 0.00000330 BTC",
 		},
@@ -570,7 +570,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			relayFeeRate := minRelayFeeRate
+			relayFeeRate := chainfee.FeePerKwFloor
 			if tc.minRelayFeeRate != 0 {
 				relayFeeRate = tc.minRelayFeeRate
 			}

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -29,6 +29,10 @@ func TestConstructUnsignedTx(t *testing.T) {
 		Hash:  chainhash.Hash{2, 2, 2},
 		Index: 2,
 	}
+	op3 := wire.OutPoint{
+		Hash:  chainhash.Hash{3, 3, 3},
+		Index: 3,
+	}
 
 	batchPkScript, err := txscript.PayToAddrScript(destAddr)
 	require.NoError(t, err)
@@ -39,6 +43,28 @@ func TestConstructUnsignedTx(t *testing.T) {
 	require.NoError(t, err)
 	p2trPkScript, err := txscript.PayToAddrScript(p2trAddress)
 	require.NoError(t, err)
+
+	change1Addr := "bc1pdx9ggvtjjcpaqfqk375qhdmzx9xu8dcu7w94lqfcxhh0rj" +
+		"lwyyeq5ryn6r"
+	change1Address, err := btcutil.DecodeAddress(change1Addr, nil)
+	require.NoError(t, err)
+	change1Pkscript, err := txscript.PayToAddrScript(change1Address)
+	require.NoError(t, err)
+	change1 := &wire.TxOut{
+		Value:    100_000,
+		PkScript: change1Pkscript,
+	}
+
+	change2Addr := "bc1psw0nrrulq4pgyuyk09a3wsutygltys4gxjjw3zl2uz4ep8pa" +
+		"r2vsvntfe0"
+	change2Address, err := btcutil.DecodeAddress(change2Addr, nil)
+	require.NoError(t, err)
+	change2Pkscript, err := txscript.PayToAddrScript(change2Address)
+	require.NoError(t, err)
+	change2 := &wire.TxOut{
+		Value:    200_000,
+		PkScript: change2Pkscript,
+	}
 
 	serializedPubKey := []byte{
 		0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
@@ -70,12 +96,15 @@ func TestConstructUnsignedTx(t *testing.T) {
 		return fmt.Errorf("weight estimator test failure")
 	}
 
+	dustLimit := utils.DustLimitForPkScript(batchPkScript)
+
 	cases := []struct {
 		name             string
 		sweeps           []sweep
 		address          btcutil.Address
 		currentHeight    int32
 		feeRate          chainfee.SatPerKWeight
+		minRelayFeeRate  chainfee.SatPerKWeight
 		wantErr          string
 		wantTx           *wire.MsgTx
 		wantWeight       lntypes.WeightUnit
@@ -223,7 +252,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 				},
 				TxOut: []*wire.TxOut{
 					{
-						Value:    2400000,
+						Value:    2_400_000,
 						PkScript: batchPkScript,
 					},
 				},
@@ -265,7 +294,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 				},
 				TxOut: []*wire.TxOut{
 					{
-						Value:    2999211,
+						Value:    2_999_211,
 						PkScript: batchPkScript,
 					},
 				},
@@ -273,6 +302,208 @@ func TestConstructUnsignedTx(t *testing.T) {
 			wantWeight:       789,
 			wantFeeForWeight: 789,
 			wantFee:          789,
+		},
+
+		{
+			name: "single sweep with change",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+					change:   change1,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    899_384,
+						PkScript: p2trPkScript,
+					},
+					{
+						Value:    change1.Value,
+						PkScript: change1.PkScript,
+					},
+				},
+			},
+			wantWeight:       616,
+			wantFeeForWeight: 616,
+			wantFee:          616,
+		},
+
+		{
+			name: "all sweeps different change outputs",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+					change:   change1,
+				},
+				{
+					outpoint: op3,
+					value:    3_000_000,
+					change:   change2,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+					{
+						PreviousOutPoint: op2,
+					},
+					{
+						PreviousOutPoint: op3,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    5_698_752,
+						PkScript: p2trPkScript,
+					},
+					{
+						Value:    change1.Value,
+						PkScript: change1.PkScript,
+					},
+					{
+						Value:    change2.Value,
+						PkScript: change2.PkScript,
+					},
+				},
+			},
+			wantWeight:       1248,
+			wantFeeForWeight: 1248,
+			wantFee:          1248,
+		},
+
+		{
+			name: "change exceeds input value",
+			sweeps: []sweep{
+				{
+					outpoint: op2,
+					value:    btcutil.Amount(change1.Value - 1),
+					change:   change1,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    change1.Value,
+						PkScript: change1.PkScript,
+					},
+				},
+			},
+			wantErr: "batch amount 0.00099999 BTC is <= the sum " +
+				"of change outputs 0.00100000 BTC",
+		},
+
+		{
+			name: "main output dust, batch amount less than " +
+				"change+fee+dust",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    dustLimit,
+				},
+				{
+					outpoint: op2,
+					value:    btcutil.Amount(change1.Value),
+					change:   change1,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1,
+			wantErr: "batch amount 0.00100294 BTC is <= the sum " +
+				"of change outputs 0.00100000 BTC plus fee " +
+				"0.00000001 BTC and dust limit 0.00000330 BTC",
+		},
+
+		{
+			name: "change output is dust",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+					change: &wire.TxOut{
+						Value:    int64(dustLimit - 1),
+						PkScript: []byte{0xaf, 0xfe},
+					},
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantErr: "output 0.00000293 BTC is below dust limit " +
+				"0.00000477 BTC",
+		},
+
+		{
+			name: "clamp fee to max fee to swap amount ratio",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    btcutil.SatoshiPerBitcoin,
+					change: &wire.TxOut{
+						Value:    btcutil.SatoshiPerBitcoin * 0.9,
+						PkScript: change1Pkscript,
+					},
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       10000000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    btcutil.SatoshiPerBitcoin * 0.08,
+						PkScript: p2trPkScript,
+					},
+					{
+						Value:    btcutil.SatoshiPerBitcoin * 0.9,
+						PkScript: change1.PkScript,
+					},
+				},
+			},
+			wantWeight:       616,
+			wantFeeForWeight: 6_160_000,
+			wantFee:          2_000_000,
 		},
 
 		{
@@ -338,9 +569,13 @@ func TestConstructUnsignedTx(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			relayFeeRate := minRelayFeeRate
+			if tc.minRelayFeeRate != 0 {
+				relayFeeRate = tc.minRelayFeeRate
+			}
 			tx, weight, feeForW, fee, err := constructUnsignedTx(
 				tc.sweeps, tc.address, tc.currentHeight,
-				tc.feeRate,
+				tc.feeRate, relayFeeRate,
 			)
 			if tc.wantErr != "" {
 				require.Error(t, err)

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -440,12 +440,13 @@ func TestConstructUnsignedTx(t *testing.T) {
 					change:   change1,
 				},
 			},
-			address:       p2trAddress,
-			currentHeight: 800_000,
-			feeRate:       1,
+			address:         p2trAddress,
+			currentHeight:   800_000,
+			feeRate:         1_000,
+			minRelayFeeRate: 50,
 			wantErr: "batch amount 0.00100294 BTC is <= the sum " +
 				"of change outputs 0.00100000 BTC plus fee " +
-				"0.00000001 BTC and dust limit 0.00000330 BTC",
+				"0.00000058 BTC and dust limit 0.00000330 BTC",
 		},
 
 		{

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -125,6 +125,9 @@ type SweepInfo struct {
 	// value should be stable for a sweep. Currently presigned and
 	// non-presigned sweeps never appear in the same batch.
 	IsPresigned bool
+
+	// Change is an optional change output of the sweep.
+	Change *wire.TxOut
 }
 
 // SweepFetcher is used to get details of a sweep.
@@ -168,7 +171,10 @@ type PresignedHelper interface {
 	// SignTx signs an unsigned transaction or returns a pre-signed tx.
 	// It must satisfy the following invariants:
 	//   - the set of inputs is the same, though the order may change;
-	//   - the output is the same, but its amount may be different;
+	//   - the main output is the same, but its amount may be different;
+	//   - the main output is the first output in the transaction;
+	//   - an optional set of change outputs may be added, the values and
+	//     pkscripts must be preserved.
 	//   - feerate is higher or equal to minRelayFee;
 	//   - LockTime may be decreased;
 	//   - transaction version must be the same;
@@ -177,6 +183,7 @@ type PresignedHelper interface {
 	// When choosing a presigned transaction, a transaction with fee rate
 	// closer to the fee rate passed is selected. If loadOnly is set, it
 	// doesn't try to sign the transaction and only loads a presigned tx.
+	// These rules are enforced by CheckSignedTx function.
 	SignTx(ctx context.Context, primarySweepID wire.OutPoint,
 		tx *wire.MsgTx, inputAmt btcutil.Amount,
 		minRelayFee, feeRate chainfee.SatPerKWeight,
@@ -711,9 +718,11 @@ func (b *Batcher) Run(ctx context.Context) error {
 // group. This method must be called prior to AddSweep if presigned mode is
 // enabled, otherwise AddSweep will fail. All the sweeps must belong to the same
 // swap. The order of sweeps is important. The first sweep serves as
-// primarySweepID if the group starts a new batch.
+// primarySweepID if the group starts a new batch. The change output may be nil
+// to indicate that the sweep group does not create a change output.
 func (b *Batcher) PresignSweepsGroup(ctx context.Context, inputs []Input,
-	sweepTimeout int32, destAddress btcutil.Address) error {
+	sweepTimeout int32, destAddress btcutil.Address,
+	changeOutput *wire.TxOut) error {
 
 	if len(inputs) == 0 {
 		return fmt.Errorf("no inputs passed to PresignSweepsGroup")
@@ -744,6 +753,9 @@ func (b *Batcher) PresignSweepsGroup(ctx context.Context, inputs []Input,
 			timeout:  sweepTimeout,
 		}
 	}
+
+	// Set the change output on the primary group sweep.
+	sweeps[0].change = changeOutput
 
 	// The sweeps are ordered inside the group, the first one is the primary
 	// outpoint in the batch.
@@ -1564,6 +1576,7 @@ func (b *Batcher) loadSweep(ctx context.Context, swapHash lntypes.Hash,
 		minFeeRate:             minFeeRate,
 		nonCoopHint:            s.NonCoopHint,
 		presigned:              s.IsPresigned,
+		change:                 s.Change,
 	}, nil
 }
 

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -228,7 +228,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -237,7 +237,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -275,7 +275,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -284,7 +284,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -321,7 +321,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value:    333,
+			Value:    3333,
 			Outpoint: op3,
 		}},
 		Notifier: &dummyNotifier,
@@ -330,7 +330,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance + 1,
-			AmountRequested: 333,
+			AmountRequested: 3333,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -538,7 +538,7 @@ func testTxLabeler(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -547,7 +547,7 @@ func testTxLabeler(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -691,7 +691,7 @@ func testPublishErrorHandler(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{1, 1},
 				Index: 1,
@@ -703,7 +703,7 @@ func testPublishErrorHandler(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -773,7 +773,7 @@ func testSweepBatcherSimpleLifecycle(t *testing.T, store testStore,
 		Index: 1,
 	}
 	const (
-		inputValue  = 111
+		inputValue  = 1111
 		outputValue = 50
 		fee         = inputValue - outputValue
 	)
@@ -1208,7 +1208,7 @@ func testSweepBatcherSkippedTxns(t *testing.T, store testStore,
 	}
 	swapHash := lntypes.Hash{1, 1, 1}
 	const (
-		inputValue       = 111
+		inputValue       = 1111
 		initiationHeight = 550
 	)
 
@@ -1418,7 +1418,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -1427,7 +1427,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      1000,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -1711,7 +1711,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{2, 2},
 				Index: 2,
@@ -1726,7 +1726,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 			// CltvExpiry is not urgent, but close.
 			CltvExpiry: 600 + blocksInDelay*2 + 5,
 
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -1794,7 +1794,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{3, 3},
 				Index: 3,
@@ -1807,7 +1807,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 			// CltvExpiry is urgent.
 			CltvExpiry: 600 + blocksInDelay*2 - 5,
 
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -1870,8 +1870,8 @@ func testCustomDelays(t *testing.T, store testStore,
 	swapHash2 := lntypes.Hash{2, 2, 2}
 
 	const (
-		swapSize1 = 111
-		swapSize2 = 222
+		swapSize1 = 1111
+		swapSize2 = 2222
 	)
 
 	// initialDelay returns initialDelay depending of batch size (sats).
@@ -1944,7 +1944,7 @@ func testCustomDelays(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      1000,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2012,7 +2012,7 @@ func testCustomDelays(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      1000,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2151,7 +2151,7 @@ func testMaxSweepsPerBatch(t *testing.T, store testStore,
 		sweepReq := SweepRequest{
 			SwapHash: swapHash,
 			Inputs: []Input{{
-				Value:    111,
+				Value:    1111,
 				Outpoint: outpoint,
 			}},
 			Notifier: &dummyNotifier,
@@ -2160,7 +2160,7 @@ func testMaxSweepsPerBatch(t *testing.T, store testStore,
 		swap := &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      1000,
-				AmountRequested: 111,
+				AmountRequested: 1111,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 
@@ -2268,7 +2268,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 		Hash:  chainhash.Hash{1, 1},
 		Index: 1,
 	}
-	value1 := btcutil.Amount(111)
+	value1 := btcutil.Amount(1111)
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
@@ -2281,7 +2281,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2297,7 +2297,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value: 222,
+			Value: 2222,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{2, 2},
 				Index: 2,
@@ -2309,7 +2309,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2328,7 +2328,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value: 333,
+			Value: 3333,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{3, 3},
 				Index: 3,
@@ -2340,7 +2340,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 333,
+			AmountRequested: 3333,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2535,7 +2535,7 @@ func testSweepBatcherGroup(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2554,11 +2554,11 @@ func testSweepBatcherGroup(t *testing.T, store testStore,
 		Inputs: []Input{
 			{
 				Outpoint: outpoint1,
-				Value:    111,
+				Value:    1111,
 			},
 			{
 				Outpoint: outpoint2,
-				Value:    222,
+				Value:    2222,
 			},
 		},
 		Notifier: &dummyNotifier,
@@ -2620,7 +2620,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -2629,7 +2629,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2667,7 +2667,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -2676,7 +2676,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2713,7 +2713,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value:    333,
+			Value:    3333,
 			Outpoint: op3,
 		}},
 		Notifier: &dummyNotifier,
@@ -2722,7 +2722,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance + 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2798,6 +2798,8 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	lnd.SetMinRelayFee(200)
+
 	sweepStore, err := NewSweepFetcherFromSwapStore(store, lnd.ChainParams)
 	require.NoError(t, err)
 
@@ -2838,7 +2840,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -2847,7 +2849,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2865,7 +2867,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -2874,7 +2876,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2895,7 +2897,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value:    333,
+			Value:    3333,
 			Outpoint: op3,
 		}},
 		Notifier: &dummyNotifier,
@@ -2904,7 +2906,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 3,
-			AmountRequested: 333,
+			AmountRequested: 3333,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -3241,7 +3243,7 @@ func testRestoringEmptyBatch(t *testing.T, store testStore,
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op,
 		}},
 		Notifier: &dummyNotifier,
@@ -3250,7 +3252,7 @@ func testRestoringEmptyBatch(t *testing.T, store testStore,
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -3425,7 +3427,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -3438,7 +3440,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 		Contract: &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      shortCltv,
-				AmountRequested: 111,
+				AmountRequested: 1111,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 			},
@@ -3455,7 +3457,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -3468,7 +3470,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 		Contract: &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      longCltv,
-				AmountRequested: 222,
+				AmountRequested: 2222,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 			},
@@ -3523,7 +3525,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 		Contract: &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      shortCltv,
-				AmountRequested: 222,
+				AmountRequested: 2222,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 			},
@@ -3627,7 +3629,7 @@ func testRestoringPreservesConfTarget(t *testing.T, store testStore,
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op,
 		}},
 		Notifier: &dummyNotifier,
@@ -3636,7 +3638,7 @@ func testRestoringPreservesConfTarget(t *testing.T, store testStore,
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -3954,7 +3956,7 @@ func testSweepBatcherCloseDuringAdding(t *testing.T, store testStore,
 		swap := &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      111,
-				AmountRequested: 111,
+				AmountRequested: 1111,
 
 				// Make preimage unique to pass SQL constraints.
 				Preimage: lntypes.Preimage{i},
@@ -3980,7 +3982,7 @@ func testSweepBatcherCloseDuringAdding(t *testing.T, store testStore,
 			sweepReq := SweepRequest{
 				SwapHash: lntypes.Hash{i, i, i},
 				Inputs: []Input{{
-					Value: 111,
+					Value: 1111,
 					Outpoint: wire.OutPoint{
 						Hash:  chainhash.Hash{i, i},
 						Index: 1,
@@ -4062,7 +4064,7 @@ func testCustomSignMuSig2(t *testing.T, store testStore,
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{1, 1},
 				Index: 1,
@@ -4074,7 +4076,7 @@ func testCustomSignMuSig2(t *testing.T, store testStore,
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},

--- a/utils/dust_limit.go
+++ b/utils/dust_limit.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/mempool"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// DustLimitForPkScript returns the dust limit for a given pkScript. An output
+// must be greater or equal to this value.
+func DustLimitForPkScript(pkscript []byte) btcutil.Amount {
+	return btcutil.Amount(mempool.GetDustThreshold(&wire.TxOut{
+		PkScript: pkscript,
+	}))
+}

--- a/utils/dust_limit_test.go
+++ b/utils/dust_limit_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+type pkScriptGetter func([]byte) ([]byte, error)
+
+// TestDustLimitForPkScript checks that the dust limit for a given script size
+// matches the calculation in lnwallet.DustLimitForSize.
+func TestDustLimitForPkScript(t *testing.T) {
+	getScripts := map[int]pkScriptGetter{
+		input.P2WPKHSize: input.WitnessPubKeyHash,
+		input.P2WSHSize:  input.WitnessScriptHash,
+		input.P2SHSize:   input.GenerateP2SH,
+		input.P2PKHSize:  input.GenerateP2PKH,
+	}
+
+	for scriptSize, getPkScript := range getScripts {
+		pkScript, err := getPkScript([]byte{})
+		require.NoError(t, err, "failed to generate pkScript")
+
+		require.Equal(
+			t, lnwallet.DustLimitForSize(scriptSize),
+			DustLimitForPkScript(pkScript),
+		)
+	}
+}


### PR DESCRIPTION
 - ensurePresigned: use passed minRelayFeeRate instead of chainfee.FeePerKwFloor
 - presign: use minRelayFeeRate for start and minRelayFee
 - presign: make sure minRelayFeeRate is set
 - add tests for presign to test this new behavior; make sure the number of transactions is lower if minRelayFeeRate is higher
 - update error message in constructUnsignedTx: use <, not <= (more accurate)
 - use utils.DustLimitForPkScript instead of lnwallet.DustLimitForSize in tests
 - in tests adjust amounts to edge values, add controls

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
